### PR TITLE
chore: remove `moved` blocks

### DIFF
--- a/terraform/aws/cognito.tf
+++ b/terraform/aws/cognito.tf
@@ -28,18 +28,3 @@ resource "aws_cognito_user_pool_domain" "domain" {
   domain       = "valentine-auth"
   user_pool_id = aws_cognito_user_pool.valentine_user_pool[0].id
 }
-
-moved {
-  from = aws_cognito_user_pool.valentine_user_pool
-  to   = aws_cognito_user_pool.valentine_user_pool[0]
-}
-
-moved {
-  from = aws_cognito_user_pool_client.client
-  to   = aws_cognito_user_pool_client.client[0]
-}
-
-moved {
-  from = aws_cognito_user_pool_domain.domain
-  to   = aws_cognito_user_pool_domain.domain[0]
-}

--- a/terraform/aws/ssm.tf
+++ b/terraform/aws/ssm.tf
@@ -133,38 +133,3 @@ resource "aws_ssm_parameter" "secret_key_base" {
     Terraform  = true
   }
 }
-
-moved {
-  from = aws_ssm_parameter.cognito_aws_region
-  to   = aws_ssm_parameter.cognito_aws_region[0]
-}
-
-moved {
-  from = aws_ssm_parameter.cognito_client_id
-  to   = aws_ssm_parameter.cognito_client_id[0]
-}
-
-moved {
-  from = aws_ssm_parameter.cognito_client_secret
-  to   = aws_ssm_parameter.cognito_client_secret[0]
-}
-
-moved {
-  from = aws_ssm_parameter.cognito_domain
-  to   = aws_ssm_parameter.cognito_domain[0]
-}
-
-moved {
-  from = aws_ssm_parameter.cognito_user_pool_id
-  to   = aws_ssm_parameter.cognito_user_pool_id[0]
-}
-
-moved {
-  from = aws_ssm_parameter.google_client_id
-  to   = aws_ssm_parameter.google_client_id[0]
-}
-
-moved {
-  from = aws_ssm_parameter.google_client_secret
-  to   = aws_ssm_parameter.google_client_secret[0]
-}


### PR DESCRIPTION
# Summary
Remove the `moved` blocks now that the state migration has been performed.