### PR TITLE
feat: add dedicated guardian key

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -14,6 +14,7 @@ env:
   TF_VAR_azure_openai_key: ${{ secrets.PRODUCTION_AZURE_OPENAI_KEY }}
   TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID }}
   TF_VAR_google_client_secret: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_guardian_secret_key: ${{ secrets.PRODUCTION_GUARDIAN_SECRET_KEY }}
   TF_VAR_secret_key_base: ${{ secrets.PRODUCTION_SECRET_KEY_BASE }}
 
 permissions:

--- a/.github/workflows/terraform-apply-user-testing.yml
+++ b/.github/workflows/terraform-apply-user-testing.yml
@@ -16,6 +16,7 @@ env:
   TF_INPUT: false
   TF_VAR_azure_openai_endpoint: ${{ secrets.USER_TESTING_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.USER_TESTING_AZURE_OPENAI_KEY }}
+  TF_VAR_guardian_secret_key: ${{ secrets.USER_TESTING_GUARDIAN_SECRET_KEY }}
   TF_VAR_secret_key_base: ${{ secrets.USER_TESTING_SECRET_KEY_BASE }}
 
 permissions:

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -16,6 +16,7 @@ env:
   TF_VAR_azure_openai_key: ${{ secrets.PRODUCTION_AZURE_OPENAI_KEY }}
   TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID }}
   TF_VAR_google_client_secret: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_guardian_secret_key: ${{ secrets.PRODUCTION_GUARDIAN_SECRET_KEY }}
   TF_VAR_secret_key_base: ${{ secrets.PRODUCTION_SECRET_KEY_BASE }}
 
 permissions:

--- a/.github/workflows/terraform-plan-user-testing.yml
+++ b/.github/workflows/terraform-plan-user-testing.yml
@@ -14,6 +14,7 @@ env:
   TF_INPUT: false
   TF_VAR_azure_openai_endpoint: ${{ secrets.USER_TESTING_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.USER_TESTING_AZURE_OPENAI_KEY }}
+  TF_VAR_guardian_secret_key: ${{ secrets.USER_TESTING_GUARDIAN_SECRET_KEY }}
   TF_VAR_secret_key_base: ${{ secrets.USER_TESTING_SECRET_KEY_BASE }}
 
 permissions:

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -30,6 +30,7 @@ data "template_file" "valentine" {
     DATABASE_URL             = aws_ssm_parameter.database_url.arn
     GOOGLE_CLIENT_ID         = var.create_google_auth ? aws_ssm_parameter.google_client_id[0].arn : ""
     GOOGLE_CLIENT_SECRET     = var.create_google_auth ? aws_ssm_parameter.google_client_secret[0].arn : ""
+    GUARDIAN_SECRET_KEY      = aws_ssm_parameter.guardian_secret_key.arn
     PHX_HOST                 = aws_acm_certificate.valentine.domain_name
     SECRET_KEY_BASE          = aws_ssm_parameter.secret_key_base.arn
   }

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "valentine_secrets_manager" {
         aws_ssm_parameter.azure_openai_endpoint.arn,
         aws_ssm_parameter.azure_openai_key.arn,
         aws_ssm_parameter.database_url.arn,
+        aws_ssm_parameter.guardian_secret_key.arn,
         aws_ssm_parameter.secret_key_base.arn
       ],
       (var.create_cognito_user_pool ?

--- a/terraform/aws/ssm.tf
+++ b/terraform/aws/ssm.tf
@@ -123,6 +123,17 @@ resource "aws_ssm_parameter" "google_client_secret" {
   }
 }
 
+resource "aws_ssm_parameter" "guardian_secret_key" {
+  name  = "guardian_secret_key"
+  type  = "SecureString"
+  value = var.guardian_secret_key
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
 resource "aws_ssm_parameter" "secret_key_base" {
   name  = "secret_key_base"
   type  = "SecureString"

--- a/terraform/aws/templates/valentine.json.tpl
+++ b/terraform/aws/templates/valentine.json.tpl
@@ -77,6 +77,10 @@
             },
             %{ endif }
             {
+                "name": "GUARDIAN_SECRET_KEY",
+                "valueFrom": "${GUARDIAN_SECRET_KEY}"
+            },
+            {
                 "name": "SECRET_KEY_BASE",
                 "valueFrom": "${SECRET_KEY_BASE}"
             }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -69,6 +69,12 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "guardian_secret_key" {
+  description = "(Required) The Guardian secret key for the application"
+  type        = string
+  sensitive   = true
+}
+
 variable "region" {
   description = "The AWS region to deploy resources in"
   type        = string


### PR DESCRIPTION
This pull request introduces support for managing a new sensitive environment variable, `GUARDIAN_SECRET_KEY`, across both GitHub Actions workflows and Terraform AWS infrastructure. The changes ensure that the secret is properly passed from CI/CD pipelines to AWS SSM Parameter Store and injected into the ECS task definition for use by the application.

**Workflow and Infrastructure Updates:**

*GitHub Actions workflows:*
- Added `TF_VAR_guardian_secret_key` to the environment configuration for production and user-testing workflows, sourcing the value from the appropriate GitHub secrets. [[1]](diffhunk://#diff-b5640808df46cf750760b788b4e32f53fc06b9f8464da17b313a2a9c3c2e4d18R17) [[2]](diffhunk://#diff-367e8f4fd141c76f2cdf75366cccece875a9abf492b3e24d063196d917ff37beR19) [[3]](diffhunk://#diff-b0a22094ffdfbc5ff7d7ccd7092938d375b899377e9732b2875e45909dec832cR19) [[4]](diffhunk://#diff-92c5ef6b60e0a637c1307bf796a65243a0672e2fdecf22d8194a4059b2bfc3c1R17)

*Terraform AWS configuration:*
- Defined a new `aws_ssm_parameter.guardian_secret_key` resource to securely store the secret in AWS SSM Parameter Store.
- Updated the ECS task template (`valentine.json.tpl`) to inject the `GUARDIAN_SECRET_KEY` environment variable from SSM.
- Modified the IAM policy to grant access to the new SSM parameter for ECS tasks.
- Updated the template file and variables to reference and require the new `guardian_secret_key` variable. [[1]](diffhunk://#diff-f8e859633c0340deae0d4b910645ab287721b4fdd3dbe7b46af4f231a9204fa5R33) [[2]](diffhunk://#diff-e0beaf635e7e58ca4243047eed9acca64a5426826fb4c19579c3fef5c6cc6cc2R72-R77)