### PR TITLE
fix: sync db versions

### DIFF
--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -10,7 +10,7 @@ module "rds_cluster" {
 
   database_name  = "valentine"
   engine         = "aurora-postgresql"
-  engine_version = "14.17"
+  engine_version = "14.20"
   instance_class = "db.t3.medium"
   instances      = 1
   username       = "valentine"


### PR DESCRIPTION
Apply failed because the DB upgraded to 14.20 automatically but TF was still at 14.17 and it tried to downgrade.