### PR TITLE
feat: add generic LLM env vars

### DIFF
--- a/.github/workflows/terraform-apply-production.yml
+++ b/.github/workflows/terraform-apply-production.yml
@@ -10,6 +10,8 @@ env:
   TERRAFORM_VERSION: 1.12.2
   TERRAGRUNT_VERSION: 0.81.7
   TF_INPUT: false
+  TF_VAR_ai_api_key: ${{ secrets.PRODUCTION_AI_API_KEY }}
+  TF_VAR_ai_base_url: ${{ secrets.PRODUCTION_AI_BASE_URL }}
   TF_VAR_azure_openai_endpoint: ${{ secrets.PRODUCTION_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.PRODUCTION_AZURE_OPENAI_KEY }}
   TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID }}

--- a/.github/workflows/terraform-apply-user-testing.yml
+++ b/.github/workflows/terraform-apply-user-testing.yml
@@ -14,6 +14,8 @@ env:
   TERRAFORM_VERSION: 1.12.2
   TERRAGRUNT_VERSION: 0.81.7
   TF_INPUT: false
+  TF_VAR_ai_api_key: ${{ secrets.USER_TESTING_AI_API_KEY }}
+  TF_VAR_ai_base_url: ${{ secrets.USER_TESTING_AI_BASE_URL }}
   TF_VAR_azure_openai_endpoint: ${{ secrets.USER_TESTING_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.USER_TESTING_AZURE_OPENAI_KEY }}
   TF_VAR_guardian_secret_key: ${{ secrets.USER_TESTING_GUARDIAN_SECRET_KEY }}

--- a/.github/workflows/terraform-plan-production.yml
+++ b/.github/workflows/terraform-plan-production.yml
@@ -12,6 +12,8 @@ env:
   TERRAGRUNT_VERSION: 0.81.7
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_INPUT: false
+  TF_VAR_ai_api_key: ${{ secrets.PRODUCTION_AI_API_KEY }}
+  TF_VAR_ai_base_url: ${{ secrets.PRODUCTION_AI_BASE_URL }}
   TF_VAR_azure_openai_endpoint: ${{ secrets.PRODUCTION_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.PRODUCTION_AZURE_OPENAI_KEY }}
   TF_VAR_google_client_id: ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID }}

--- a/.github/workflows/terraform-plan-user-testing.yml
+++ b/.github/workflows/terraform-plan-user-testing.yml
@@ -12,6 +12,8 @@ env:
   TERRAGRUNT_VERSION: 0.81.7
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_INPUT: false
+  TF_VAR_ai_api_key: ${{ secrets.USER_TESTING_AI_API_KEY }}
+  TF_VAR_ai_base_url: ${{ secrets.USER_TESTING_AI_BASE_URL }}
   TF_VAR_azure_openai_endpoint: ${{ secrets.USER_TESTING_AZURE_OPENAI_ENDPOINT }}
   TF_VAR_azure_openai_key: ${{ secrets.USER_TESTING_AZURE_OPENAI_KEY }}
   TF_VAR_guardian_secret_key: ${{ secrets.USER_TESTING_GUARDIAN_SECRET_KEY }}

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -18,6 +18,8 @@ data "template_file" "valentine" {
     fargate_cpu              = var.fargate_cpu
     fargate_memory           = var.fargate_memory
     aws_region               = var.region
+    AI_API_KEY               = aws_ssm_parameter.ai_api_key.arn
+    AI_BASE_URL              = aws_ssm_parameter.ai_base_url.arn
     AZURE_OPENAI_ENDPOINT    = aws_ssm_parameter.azure_openai_endpoint.arn
     AZURE_OPENAI_KEY         = aws_ssm_parameter.azure_openai_key.arn
     COGNITO_DOMAIN           = var.create_cognito_user_pool ? aws_ssm_parameter.cognito_domain[0].arn : ""

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -17,6 +17,8 @@ data "aws_iam_policy_document" "valentine_secrets_manager" {
     ]
     resources = concat(
       [
+        aws_ssm_parameter.ai_api_key.arn,
+        aws_ssm_parameter.ai_base_url.arn,
         aws_ssm_parameter.azure_openai_endpoint.arn,
         aws_ssm_parameter.azure_openai_key.arn,
         aws_ssm_parameter.database_url.arn,

--- a/terraform/aws/ssm.tf
+++ b/terraform/aws/ssm.tf
@@ -1,3 +1,25 @@
+resource "aws_ssm_parameter" "ai_api_key" {
+  name  = "ai_api_key"
+  type  = "SecureString"
+  value = var.ai_api_key
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_ssm_parameter" "ai_base_url" {
+  name  = "ai_base_url"
+  type  = "SecureString"
+  value = var.ai_base_url
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
 resource "aws_ssm_parameter" "azure_openai_endpoint" {
   name  = "azure_openai_endpoint"
   type  = "SecureString"

--- a/terraform/aws/templates/valentine.json.tpl
+++ b/terraform/aws/templates/valentine.json.tpl
@@ -33,6 +33,14 @@
         ],
         "secrets": [
             {
+                "name": "AI_API_KEY",
+                "valueFrom": "${AI_API_KEY}"
+            },
+            {
+                "name": "AI_BASE_URL",
+                "valueFrom": "${AI_BASE_URL}"
+            },
+            {
                 "name": "AZURE_OPENAI_ENDPOINT",
                 "valueFrom": "${AZURE_OPENAI_ENDPOINT}"
             },

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -3,6 +3,18 @@ variable "account_id" {
   type        = string
 }
 
+variable "ai_api_key" {
+  description = "(Required) The API key for the AI service"
+  type        = string
+  sensitive   = true
+}
+
+variable "ai_base_url" {
+  description = "(Required) The base URL for the AI service"
+  type        = string
+  sensitive   = true
+}
+
 variable "azure_openai_endpoint" {
   description = "(Optional) The Azure OpenAI endpoint"
   type        = string


### PR DESCRIPTION
This pull request adds support for securely managing and injecting AI service credentials (API key and base URL) into the Terraform infrastructure for both production and user testing environments. The changes ensure these secrets are stored in AWS SSM Parameter Store, referenced in ECS task definitions, and passed through GitHub Actions workflows.

**Infrastructure changes for AI service credentials:**

* Added new sensitive Terraform variables `ai_api_key` and `ai_base_url` to `variables.tf` for configuring the AI service credentials.
* Created new `aws_ssm_parameter` resources in `ssm.tf` to securely store the AI API key and base URL in AWS SSM Parameter Store.
* Updated ECS task definition template (`valentine.json.tpl`) and its data source to inject the AI credentials as secrets into the ECS container environment. [[1]](diffhunk://#diff-f8e859633c0340deae0d4b910645ab287721b4fdd3dbe7b46af4f231a9204fa5R21-R22) [[2]](diffhunk://#diff-44081c1ef07a531a117ffb38152f9610edd651fcb464a2b0abdddeaa8bc56742R35-R42)

**IAM and permissions updates:**

* Modified the IAM policy document to grant access to the new SSM parameters for the AI API key and base URL.

**CI/CD workflow integration:**

* Updated GitHub Actions workflows (`terraform-plan-production.yml`, `terraform-apply-production.yml`, `terraform-plan-user-testing.yml`, `terraform-apply-user-testing.yml`) to pass the appropriate AI service credentials as environment variables using GitHub secrets for both production and user testing environments. [[1]](diffhunk://#diff-367e8f4fd141c76f2cdf75366cccece875a9abf492b3e24d063196d917ff37beR15-R16) [[2]](diffhunk://#diff-b5640808df46cf750760b788b4e32f53fc06b9f8464da17b313a2a9c3c2e4d18R13-R14) [[3]](diffhunk://#diff-92c5ef6b60e0a637c1307bf796a65243a0672e2fdecf22d8194a4059b2bfc3c1R15-R16) [[4]](diffhunk://#diff-b0a22094ffdfbc5ff7d7ccd7092938d375b899377e9732b2875e45909dec832cR17-R18)